### PR TITLE
Fix stale search previews

### DIFF
--- a/quartz/components/scripts/search.inline.ts
+++ b/quartz/components/scripts/search.inline.ts
@@ -2,6 +2,7 @@ import FlexSearch, { DefaultDocumentSearchResults } from "flexsearch"
 import { SearchIndexDetails } from "../../plugins/emitters/contentIndex"
 import { registerEscapeHandler, removeAllChildren } from "./util"
 import { FullSlug, normalizeRelativeURLs, resolveRelative } from "../../util/path"
+import { createRequestTracker, ensureSuccessfulSearchPreviewResponse } from "./searchPreview"
 
 type ContentIndex = Record<FullSlug, SearchIndexDetails>
 
@@ -314,6 +315,8 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug) {
     searchLayout.dataset.preview === "true" && window.matchMedia("(min-width: 900px)").matches
   let preview: HTMLDivElement | undefined = undefined
   let previewInner: HTMLDivElement | undefined = undefined
+  const previewRequests = createRequestTracker()
+  const searchRequests = createRequestTracker()
   const results = document.createElement("div")
   results.className = "results-container"
   appendLayout(results)
@@ -325,6 +328,8 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug) {
   }
 
   function hideSearch() {
+    previewRequests.invalidate()
+    searchRequests.invalidate()
     container.classList.remove("active")
     searchBar.value = "" // clear the input when we dismiss the search
     if (sidebar) sidebar.style.zIndex = ""
@@ -338,6 +343,7 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug) {
   }
 
   function showSearch(searchTypeNew: SearchType) {
+    previewRequests.invalidate()
     searchType = searchTypeNew
     if (sidebar) sidebar.style.zIndex = "1"
     container.classList.add("active")
@@ -509,8 +515,8 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug) {
     }
 
     async function onMouseEnter(ev: MouseEvent) {
-      if (!ev.target) return
-      const target = ev.target as HTMLInputElement
+      if (!ev.currentTarget) return
+      const target = ev.currentTarget as HTMLElement
       await displayPreview(target)
     }
 
@@ -587,17 +593,17 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug) {
     }
 
     const targetUrl = resolveUrl(slug).toString()
-    const contents = await fetch(targetUrl)
-      .then((res) => res.text())
-      .then((contents) => {
-        if (contents === undefined) {
-          throw new Error(`Could not fetch ${targetUrl}`)
-        }
-        const html = p.parseFromString(contents ?? "", "text/html")
-        normalizeRelativeURLs(html, targetUrl)
-        return [...html.getElementsByClassName("popover-hint")]
-      })
+    const response = await fetch(targetUrl)
+    ensureSuccessfulSearchPreviewResponse(response, targetUrl)
+    const responseBody = await response.text()
+    const html = p.parseFromString(responseBody, "text/html")
+    normalizeRelativeURLs(html, targetUrl)
+    const contents = [...html.getElementsByClassName("popover-hint")]
+    if (contents.length === 0) {
+      throw new Error(`Search preview content is missing for ${targetUrl}`)
+    }
 
+    // Only successful, usable previews belong in the cache.
     fetchContentCache.set(slug, contents)
     return contents
   }
@@ -605,9 +611,35 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug) {
   async function displayPreview(el: HTMLElement | null) {
     if (!searchLayout || !enablePreview || !el || !preview) return
     const slug = el.id as FullSlug
-    const innerDiv = await fetchContent(slug).then((contents) =>
-      contents.flatMap((el) => [...highlightHTML(currentSearchTerm, el as HTMLElement).children]),
-    )
+    if (!slug) return
+
+    const requestId = previewRequests.begin()
+    const searchTerm = currentSearchTerm
+    let innerDiv: Element[]
+    try {
+      const contents = await fetchContent(slug)
+      if (!previewRequests.isCurrent(requestId)) return
+      innerDiv = contents.flatMap((content) => [
+        ...highlightHTML(searchTerm, content as HTMLElement).children,
+      ])
+    } catch (error) {
+      if (!previewRequests.isCurrent(requestId)) return
+      console.warn(error)
+      const errorPreview = document.createElement("div")
+      errorPreview.classList.add("preview-inner", "search-preview-error")
+      const heading = document.createElement("h3")
+      heading.textContent = "Peržiūros nepavyko įkelti"
+      const description = document.createElement("p")
+      description.textContent = "Rezultato puslapį vis tiek galite atidaryti."
+      const link = document.createElement("a")
+      link.href = el instanceof HTMLAnchorElement ? el.href : resolveUrl(slug).toString()
+      link.textContent = "Atidaryti rezultatą"
+      errorPreview.append(heading, description, link)
+      preview.replaceChildren(errorPreview)
+      return
+    }
+
+    if (!previewRequests.isCurrent(requestId)) return
     previewInner = document.createElement("div")
     previewInner.classList.add("preview-inner")
     previewInner.append(...innerDiv)
@@ -622,8 +654,12 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug) {
 
   async function onType(e: HTMLElementEventMap["input"]) {
     if (!searchLayout || !index) return
+    const requestId = searchRequests.begin()
+    previewRequests.invalidate()
+    const requestedSearchTerm = (e.target as HTMLInputElement).value
     await loadSearchData()
-    currentSearchTerm = (e.target as HTMLInputElement).value
+    if (!searchRequests.isCurrent(requestId)) return
+    currentSearchTerm = requestedSearchTerm
     searchLayout.classList.toggle("display-results", currentSearchTerm !== "")
     searchType = currentSearchTerm.startsWith("#") ? "tags" : "basic"
 
@@ -664,6 +700,8 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug) {
       })
     }
 
+    if (!searchRequests.isCurrent(requestId)) return
+
     const getByField = (field: string): number[] => {
       const results = searchResults.filter((x) => x.field === field)
       return results.length === 0 ? [] : ([...results[0].result] as number[])
@@ -684,6 +722,7 @@ async function setupSearch(searchElement: Element, currentSlug: FullSlug) {
       .sort((a, b) => rankResult(currentSearchTerm, b) - rankResult(currentSearchTerm, a))
       .slice(0, numSearchResults)
       .map((id) => formatForDisplay(currentSearchTerm, id))
+    if (!searchRequests.isCurrent(requestId)) return
     await displayResults(
       finalResults,
       Math.max(0, candidateIds.length - visibleIds.length),

--- a/quartz/components/scripts/search.test.ts
+++ b/quartz/components/scripts/search.test.ts
@@ -1,5 +1,7 @@
 import test, { describe } from "node:test"
 import assert from "node:assert"
+import { FullSlug, resolveRelative } from "../../util/path"
+import { createRequestTracker, ensureSuccessfulSearchPreviewResponse } from "./searchPreview"
 
 type SearchOptionsState = {
   minClaimCount: number
@@ -293,6 +295,61 @@ describe("search option filters", () => {
         { minClaimCount: 1, sourceSelectionMode: "custom", selectedSourceIds: ["eidintas-2013"] },
       ),
       false,
+    )
+  })
+})
+
+describe("search preview requests", () => {
+  test("only the latest delayed preview may render", async () => {
+    const requests = createRequestTracker()
+    const rendered: string[] = []
+    let releaseFirst: (() => void) | undefined
+
+    const renderAfter = async (value: string, pending: Promise<void>) => {
+      const requestId = requests.begin()
+      await pending
+      if (requests.isCurrent(requestId)) rendered.push(value)
+    }
+
+    const firstPending = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const first = renderAfter("old", firstPending)
+    const second = renderAfter("new", Promise.resolve())
+    await second
+    releaseFirst?.()
+    await first
+
+    assert.deepStrictEqual(rendered, ["new"])
+  })
+
+  test("rejects a 404 preview response", () => {
+    assert.throws(
+      () =>
+        ensureSuccessfulSearchPreviewResponse(
+          { ok: false, status: 404 },
+          "https://lietuvosistorija.eu/missing",
+        ),
+      /HTTP 404/,
+    )
+  })
+
+  test("accepts a successful preview response", () => {
+    assert.doesNotThrow(() =>
+      ensureSuccessfulSearchPreviewResponse(
+        { ok: true, status: 200 },
+        "https://lietuvosistorija.eu/objektai/asmenys/Steponas-Batoras",
+      ),
+    )
+  })
+
+  test("resolves the Steponas Batoras result from a nested page", () => {
+    assert.equal(
+      resolveRelative(
+        "objektai/vietos/Gardinas" as FullSlug,
+        "objektai/asmenys/Steponas-Batoras" as FullSlug,
+      ),
+      "../../objektai/asmenys/Steponas-Batoras",
     )
   })
 })

--- a/quartz/components/scripts/searchPreview.ts
+++ b/quartz/components/scripts/searchPreview.ts
@@ -1,0 +1,26 @@
+export type RequestTracker = {
+  begin: () => number
+  invalidate: () => void
+  isCurrent: (requestId: number) => boolean
+}
+
+export function createRequestTracker(): RequestTracker {
+  let latestRequestId = 0
+
+  return {
+    begin: () => ++latestRequestId,
+    invalidate: () => {
+      latestRequestId += 1
+    },
+    isCurrent: (requestId) => requestId === latestRequestId,
+  }
+}
+
+export function ensureSuccessfulSearchPreviewResponse(
+  response: Pick<Response, "ok" | "status">,
+  targetUrl: string,
+): void {
+  if (!response.ok) {
+    throw new Error(`Could not fetch search preview ${targetUrl}: HTTP ${response.status}`)
+  }
+}

--- a/quartz/components/styles/search.scss
+++ b/quartz/components/styles/search.scss
@@ -168,6 +168,23 @@
             width: min($pageWidth, 100%);
           }
 
+          & .search-preview-error {
+            padding: 2rem 0;
+
+            & > h3 {
+              margin-bottom: 0.5rem;
+            }
+
+            & > p {
+              margin: 0 0 1rem;
+            }
+
+            & > a {
+              color: var(--secondary);
+              font-weight: $boldWeight;
+            }
+          }
+
           a[role="anchor"] {
             background-color: transparent;
           }


### PR DESCRIPTION
## What changed

- prevent stale search and preview requests from overwriting the latest result
- reject non-success HTTP responses and avoid caching invalid previews
- show a compact fallback with a working result link
- add regression coverage for request ordering, 404 handling, and the Steponas Batoras route

## Root cause

The search overlay rendered whichever preview request completed last, even when it belonged to an older query. It also parsed 404 response HTML as valid preview content.

## Validation

- `npm test` (136 tests passed)
- `npx tsc --noEmit`
- `npm run build` (13,024 Markdown files; 23,448 output files)