### PR TITLE
Fix GA4 command queue

### DIFF
--- a/quartz/components/scripts/analytics.inline.ts
+++ b/quartz/components/scripts/analytics.inline.ts
@@ -5,6 +5,7 @@ import {
   ExplorationState,
   advanceExploration,
   analyticsDedupeKey,
+  createGtagCommandQueue,
   emptyExplorationState,
   normalizeSearchTerm,
   searchTermContainsPotentialPii,
@@ -24,7 +25,7 @@ type AnalyticsRuntime = {
 
 type AnalyticsWindow = Window & {
   liAnalytics?: AnalyticsRuntime
-  dataLayer?: unknown[][]
+  dataLayer?: unknown[]
 }
 
 const analyticsWindow = window as AnalyticsWindow
@@ -138,7 +139,7 @@ function installAnalytics() {
   if (analyticsWindow.liAnalytics || !analyticsEnabled()) return
 
   analyticsWindow.dataLayer = analyticsWindow.dataLayer || []
-  const gtag = (...args: unknown[]) => analyticsWindow.dataLayer!.push(args)
+  const gtag = createGtagCommandQueue(analyticsWindow.dataLayer)
   const sessionKeys = readStringSet(SESSION_DEDUPE_KEY)
   let pageKeys = new Set<string>()
   let lastPageLocation = ""

--- a/quartz/components/scripts/analytics.test.ts
+++ b/quartz/components/scripts/analytics.test.ts
@@ -5,10 +5,33 @@ import {
   advanceExploration,
   analyticsDedupeKey,
   classifyAnalyticsPage,
+  createGtagCommandQueue,
   emptyExplorationState,
   normalizeSearchTerm,
   searchTermContainsPotentialPii,
 } from "../../util/analytics"
+
+test("queues gtag commands as Arguments objects required by gtag.js", () => {
+  const dataLayer: unknown[] = []
+  const gtag = createGtagCommandQueue(dataLayer)
+
+  gtag("config", "G-TEST", { send_page_view: false })
+  gtag("event", "page_view", { page_title: "Test" })
+
+  assert.equal(dataLayer.length, 2)
+  assert.equal(Array.isArray(dataLayer[0]), false)
+  assert.equal(Object.prototype.toString.call(dataLayer[0]), "[object Arguments]")
+  assert.deepEqual(Array.from(dataLayer[0] as IArguments), [
+    "config",
+    "G-TEST",
+    { send_page_view: false },
+  ])
+  assert.deepEqual(Array.from(dataLayer[1] as IArguments), [
+    "event",
+    "page_view",
+    { page_title: "Test" },
+  ])
+})
 
 test("classifies only recognized object pages as objects", () => {
   assert.equal(classifyAnalyticsPage("objektai/asmenys/Gediminas", "asmuo").pageType, "object")

--- a/quartz/util/analytics.ts
+++ b/quartz/util/analytics.ts
@@ -1,5 +1,13 @@
 export const ANALYTICS_SCHEMA_VERSION = "ga4_events_v1"
 
+export type GtagCommand = (...args: unknown[]) => void
+
+export function createGtagCommandQueue(dataLayer: unknown[]): GtagCommand {
+  return function gtag() {
+    dataLayer.push(arguments)
+  }
+}
+
 export const ANALYTICS_EVENT_NAMES = [
   "page_view",
   "object_view",


### PR DESCRIPTION
## What changed

- queue GA4 commands as real `Arguments` objects, matching the official `gtag.js` contract
- keep the existing custom event and SPA page-view behavior unchanged
- add regression coverage proving commands are not queued as plain arrays

## Root cause

The custom `gtag` wrapper used a rest parameter and pushed the resulting array into `dataLayer`. Google Tag treats `Arguments` objects as `gtag` commands; plain arrays follow a different processing path, so `config` and `page_view` were not executed.

## Impact

Restores GA4 configuration, page views, and custom analytics events on production visits.

## Validation

- analytics tests: 5 passed
- full test suite: 143 passed
- TypeScript: passed
- Prettier: passed
- production build: 13,364 Markdown files / 24,156 emitted files
- generated bundle verified to contain `dataLayer.push(arguments)`